### PR TITLE
rsm: implement `duration_{begin,end}` dumping, etc.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -39,3 +39,8 @@ add_example(
     rsm_example_counter_2
         "counter/2.cpp"
 )
+
+add_example(
+    rsm_example_duration_1
+        "duration/1.cpp"
+)

--- a/examples/duration/1.cpp
+++ b/examples/duration/1.cpp
@@ -1,0 +1,73 @@
+#include <chrono>
+#include <thread>
+
+#include "rsm.hpp"
+#include "rsm/mark_duration.hpp"
+#include "rsm/mark_duration_begin.hpp"
+#include "rsm/mark_duration_end.hpp"
+
+int main(int argc, char const **argv) {
+  char const *const filename{argc > 1 ? argv[1] : "/dev/stdout"};
+  RSM_flush_all_collected_events(rsm::output::format::chrome_trace, filename,
+                                 true);
+
+  RSM_init_thread_local_sink();
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+  {
+    RSM_MARK_DURATION("RAII duration test");
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  RSM_MARK_DURATION_BEGIN("manual duration test");
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  RSM_MARK_DURATION_END();
+
+  std::thread{[]() {
+    RSM_init_thread_local_sink();
+    RSM_MARK_DURATION("RAII thread duration test");
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }}.join();
+
+  std::thread{[]() {
+    RSM_init_thread_local_sink();
+    RSM_MARK_DURATION_BEGIN("manual thread duration test");
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    RSM_MARK_DURATION_END();
+  }}.join();
+
+  // Test overlapping durations:
+
+  {
+    RSM_MARK_DURATION("RAII outer duration");
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+    {
+      RSM_MARK_DURATION("RAII inner duration");
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  RSM_MARK_DURATION_BEGIN("manual outer duration");
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  RSM_MARK_DURATION_BEGIN("manual inner duration");
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  RSM_MARK_DURATION_END();
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  RSM_MARK_DURATION_END();
+
+  constexpr int pyramid_height{6};
+  for (int i{0}; i < pyramid_height; ++i) {
+    RSM_MARK_DURATION_BEGIN("Pyramid level");
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  for (int i{0}; i < pyramid_height; ++i) {
+    RSM_MARK_DURATION_END();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  return 0;
+}

--- a/include/impl/event/any.hpp
+++ b/include/impl/event/any.hpp
@@ -32,7 +32,11 @@ struct any {
 
   [[nodiscard]] constexpr char const *get_name() const noexcept {
     return get_type() == event::type_t::counter ? "Counter"
-                                                : evt.common_base.c.desc;
+           : get_type() == event::type_t::duration_end
+               // TODO maybe don't return empty string, and rather skip writing
+               // out `"name":"",` completely (in `dump_records`)...:
+               ? (evt.common_base.c.desc ? evt.common_base.c.desc : "")
+               : evt.common_base.c.desc;
   }
 
   [[nodiscard]] constexpr auto get_ph() const noexcept {

--- a/include/rsm/mark_duration.hpp
+++ b/include/rsm/mark_duration.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "impl/event/any.hpp"
+#include "impl/linkage_macros.hpp"
+#include "impl/utils.hpp"
+
+#define RSM_MARK_DURATION(...)                                                 \
+  ::rsm::mark_duration RSM_IMPL_IMPLICIT_MARKER_NAME(                          \
+      RSM_IMPLICIT_DURATION_MARKER_, __LINE__) {                               \
+    __VA_ARGS__                                                                \
+  }
+
+namespace rsm {
+
+struct RSM_IMPL_API mark_duration {
+  inline mark_duration(char const *desc) noexcept {
+    RSM_IMPL_append_event(
+        impl::event::duration_begin{desc, impl::as_int_ns(impl::now())});
+  }
+
+  inline ~mark_duration() noexcept {
+    RSM_IMPL_append_event(
+        impl::event::duration_end{nullptr, impl::as_int_ns(impl::now())});
+  }
+
+private:
+  mark_duration(mark_duration const &) = delete;
+  mark_duration &operator=(mark_duration const &) = delete;
+  mark_duration(mark_duration &&) = delete;
+  mark_duration &operator=(mark_duration &&) = delete;
+};
+
+} // namespace rsm

--- a/include/rsm/mark_duration_begin.hpp
+++ b/include/rsm/mark_duration_begin.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "impl/event/any.hpp"
+#include "impl/linkage_macros.hpp"
+#include "impl/utils.hpp"
+
+#define RSM_MARK_DURATION_BEGIN(...) ::rsm::mark_duration_begin(__VA_ARGS__)
+
+namespace rsm {
+
+inline void mark_duration_begin(char const *desc) noexcept {
+  RSM_IMPL_append_event(
+      impl::event::duration_begin{desc, impl::as_int_ns(impl::now())});
+}
+
+} // namespace rsm

--- a/include/rsm/mark_duration_end.hpp
+++ b/include/rsm/mark_duration_end.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "impl/event/any.hpp"
+#include "impl/linkage_macros.hpp"
+#include "impl/utils.hpp"
+
+// Provide either same string as to the corresponding `RSM_MARK_DURATION_BEGIN`
+// call, `nullptr` or nothing at all. This is so ui.perfetto.dev processes it
+// correctly.
+#define RSM_MARK_DURATION_END(...) ::rsm::mark_duration_end(__VA_ARGS__)
+
+namespace rsm {
+
+inline void mark_duration_end(char const *desc = nullptr) noexcept {
+  RSM_IMPL_append_event(
+      impl::event::duration_end{desc, impl::as_int_ns(impl::now())});
+}
+
+} // namespace rsm

--- a/src/impl/dump_records.cpp
+++ b/src/impl/dump_records.cpp
@@ -94,11 +94,19 @@ void write_chrome_trace(std::ostream &out, impl::event::list const &list,
 
     switch (evt.get_type()) {
     case event::type_t::duration_begin: {
-      // TODO handle this
+      auto const &e{evt.evt.dur_begin};
+
+      auto const timestamp{
+          longlong_ns_to_double_us(e.start_ns - time_point_zero)};
+      out << "\"ts\":" << timestamp << ',';
       break;
     }
     case event::type_t::duration_end: {
-      // TODO handle this
+      auto const &e{evt.evt.dur_end};
+
+      auto const timestamp{
+          longlong_ns_to_double_us(e.end_ns - time_point_zero)};
+      out << "\"ts\":" << timestamp << ',';
       break;
     }
     case event::type_t::complete: {


### PR DESCRIPTION
closes #26

# Description

Self explanatory?