### PR TITLE
Better guard for `thread_local ... impl::local_sink` initialization

### DIFF
--- a/examples/counter/1.cpp
+++ b/examples/counter/1.cpp
@@ -21,11 +21,13 @@ int main(int argc, char const **argv) {
   std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
   std::thread t1{[]() {
+    CXXST_init_thread_local_sink();
     CXXST_mark_counters("thread 1 operations", 42.0);
     CXXST_mark_counters("RAM [MB]", 3.1, "cpu utilization", 62.0);
   }};
 
   std::thread t2{[]() {
+    CXXST_init_thread_local_sink();
     CXXST_mark_counters("RAM [MB]", 3.3, "cpu utilization", 52.0);
     CXXST_mark_counters("thread 2 operations", 85.3);
   }};

--- a/examples/instant/1.cpp
+++ b/examples/instant/1.cpp
@@ -17,11 +17,20 @@ int main(int argc, char const **argv) {
   // Unfortunately, using non-default scope (== `...::thread`), makes `chrome` &
   // ui.perfetto.dev display it somehow unusably ...
 
-  std::thread t1{[]() { CXXST_mark_instant("thread 1 started"); }};
+  std::thread t1{[]() {
+    CXXST_init_thread_local_sink();
+    CXXST_mark_instant("thread 1 started");
+  }};
 
-  std::thread t2{[]() { CXXST_mark_instant("thread 2 started"); }};
+  std::thread t2{[]() {
+    CXXST_init_thread_local_sink();
+    CXXST_mark_instant("thread 2 started");
+  }};
 
-  std::thread t3{[]() { CXXST_mark_instant("thread 3 started"); }};
+  std::thread t3{[]() {
+    CXXST_init_thread_local_sink();
+    CXXST_mark_instant("thread 3 started");
+  }};
 
   CXXST_mark_instant("main thread flushing all markers");
 

--- a/examples/instant/2.cpp
+++ b/examples/instant/2.cpp
@@ -19,18 +19,21 @@ int main(int argc, char const **argv) {
     // & ui.perfetto.dev display it somehow unusably ...
 
     std::thread t1{[]() {
+      CXXST_init_thread_local_sink();
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
       CXXST_mark_complete("thread 1");
       CXXST_mark_instant("thread 1 started");
     }};
 
     std::thread t2{[]() {
+      CXXST_init_thread_local_sink();
       CXXST_mark_complete("thread 2");
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
       CXXST_mark_instant("thread 2 started");
     }};
 
     std::thread t3{[]() {
+      CXXST_init_thread_local_sink();
       CXXST_mark_complete("thread 3");
       CXXST_mark_instant("thread 3 started");
       std::this_thread::sleep_for(std::chrono::milliseconds(1));


### PR DESCRIPTION
closes #61