### PR TITLE
Rename `sink::file_sink::time_point` to `time_point_zero_ns`, etc.

### DIFF
--- a/include/private/impl/dump_records.hxx
+++ b/include/private/impl/dump_records.hxx
@@ -25,7 +25,7 @@
 namespace cxxet::impl {
 
 void dump_records(impl::event::list const &list,
-                  long long const time_point_zero, output::format const fmt,
+                  long long const time_point_zero_ns, output::format const fmt,
                   char const *const filename);
 
 }

--- a/include/private/impl/sink/cascade.hxx
+++ b/include/private/impl/sink/cascade.hxx
@@ -25,8 +25,7 @@
 
 namespace cxxet::impl::sink {
 
-template <bool thread_safe_v>
-struct cascade : thread_safe_t<thread_safe_v> {
+template <bool thread_safe_v> struct cascade : thread_safe_t<thread_safe_v> {
   explicit cascade(sink_base *aParent) noexcept
       : base_class_t{}, parent{aParent} {}
 

--- a/include/private/impl/sink/file_sink.hxx
+++ b/include/private/impl/sink/file_sink.hxx
@@ -25,10 +25,10 @@
 
 namespace cxxet::impl::sink {
 
-template <bool thread_safe_v>
-struct file_sink : thread_safe_t<thread_safe_v> {
-  explicit file_sink(long long const aTime_point) noexcept;
-  explicit file_sink(long long const aTime_point, output::format const aFmt,
+template <bool thread_safe_v> struct file_sink : thread_safe_t<thread_safe_v> {
+  explicit file_sink(long long const aTime_point_zero_ns) noexcept;
+  explicit file_sink(long long const aTime_point_zero_ns,
+                     output::format const aFmt,
                      char const *const aTarget_filename) noexcept;
   explicit file_sink(properties const &traits) noexcept;
   ~file_sink() noexcept override;
@@ -46,8 +46,7 @@ private:
 
   void do_flush() noexcept;
 
-  long long const
-      time_point; // TODO better name (should at least end with units ...)
+  long long const time_point_zero_ns;
   output::format fmt{output::format::unknown};
   char const *target_filename{nullptr};
 };

--- a/src/impl/sink/file_sink.cxx
+++ b/src/impl/sink/file_sink.cxx
@@ -66,7 +66,7 @@ void file_sink<thread_safe_v>::do_flush() noexcept {
   } else if (target_filename) {
     if (!base_class_t::events.empty()) {
       try {
-        // is `time_point_zero` needed?!
+        // is `time_point_zero_ns` needed?!
         dump_records(base_class_t::events, time_point_zero_ns, fmt,
                      target_filename);
         base_class_t::events.destroy();

--- a/src/impl/sink/file_sink.cxx
+++ b/src/impl/sink/file_sink.cxx
@@ -26,14 +26,15 @@
 namespace cxxet::impl::sink {
 
 template <bool thread_safe_v>
-file_sink<thread_safe_v>::file_sink(long long const aTime_point) noexcept
-    : base_class_t{}, time_point{aTime_point} {}
+file_sink<thread_safe_v>::file_sink(
+    long long const aTime_point_zero_ns) noexcept
+    : base_class_t{}, time_point_zero_ns{aTime_point_zero_ns} {}
 
 template <bool thread_safe_v>
-file_sink<thread_safe_v>::file_sink(long long const aTime_point,
+file_sink<thread_safe_v>::file_sink(long long const aTime_point_zero_ns,
                                     output::format const aFmt,
                                     char const *const aTarget_filename) noexcept
-    : base_class_t{}, time_point{aTime_point}, fmt{aFmt},
+    : base_class_t{}, time_point_zero_ns{aTime_point_zero_ns}, fmt{aFmt},
       target_filename{aTarget_filename} {}
 
 template <bool thread_safe_v>
@@ -66,7 +67,8 @@ void file_sink<thread_safe_v>::do_flush() noexcept {
     if (!base_class_t::events.empty()) {
       try {
         // is `time_point_zero` needed?!
-        dump_records(base_class_t::events, time_point, fmt, target_filename);
+        dump_records(base_class_t::events, time_point_zero_ns, fmt,
+                     target_filename);
         base_class_t::events.destroy();
       } catch (std::exception const &e) {
         std::cerr << "Failed to dump records: " << e.what() << '\n';


### PR DESCRIPTION
closes #87 