### PR TITLE
Extract `benchmark` option from `tests` subcommand into its own one

### DIFF
--- a/scripts/commands/benchmark.bash
+++ b/scripts/commands/benchmark.bash
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e
+
+cxxet_include scripts/tests/benchmark_runner
+
+function tests() {
+    function usage() {
+        {
+            if [[ "$1" != '--short' ]]; then
+                printf 'benchmark: perform or evaluate various benchmark(s)\n'
+            fi
+            printf 'Usage: benchmark option [args ...]\n'
+            printf 'Where option is one of:\n'
+            printf '    -m, --micro, micro  Run C++ implementation micro-benchmarks\n'
+            printf '    --help, -h          Show this help message\n'
+            printf 'Remaining args are passed to the previously parsed "option", e.g. for suite-specific details/help, pass -h|--help to it.\n'
+        } >&2
+    }
+
+    case "$1" in
+        -m|--micro|micro)
+            shift
+            benchmark_runner "$@"
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            printf 'Unknown option "%s"\n' "$1" >&2
+            usage --short
+            exit 1
+            ;;
+    esac
+    return 0
+}

--- a/scripts/commands/tests.bash
+++ b/scripts/commands/tests.bash
@@ -3,7 +3,6 @@
 set -e
 
 cxxet_include scripts/tests/bats_runner
-cxxet_include scripts/tests/benchmark_runner
 cxxet_include scripts/tests/unit_runner
 cxxet_include scripts/tests/valid_examples_runner
 
@@ -19,7 +18,6 @@ function tests() {
             printf '    -u, --unit, unit            Run unit tests\n'
             printf '    -e, --examples, examples    Run "valid" examples\n'
             printf '    -b, --bats, bats            Run bats tests\n'
-            printf '    -p, --benchmark, benchmark  Run benchmarks\n'
             printf '    --help, -h                  Show this help message\n'
             printf 'Remaining args are passed to the previously parsed "option", e.g. for suite-specific details/help, pass -h|--help to it.\n'
         } >&2
@@ -43,10 +41,6 @@ function tests() {
         -u|--unit|unit)
             shift
             unit_runner "$@"
-            ;;
-        -p|--benchmark|benchmark)
-            shift
-            benchmark_runner "$@"
             ;;
         --help|-h)
             usage


### PR DESCRIPTION
closes #168 